### PR TITLE
Consolidate scheduled positions by person

### DIFF
--- a/app/services/planning_center.py
+++ b/app/services/planning_center.py
@@ -94,6 +94,41 @@ def service_items(plan: dict[str, Any], service_time_id: str | None) -> list[dic
     return result
 
 
+def consolidate_people(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Combine a person's scheduled positions while retaining plan order.
+
+    Planning Center returns one PlanPerson per position.  The dashboard, mic
+    assignment, and item-leader features instead need a single representation
+    of that human, with every scheduled position available for lookup.
+    """
+    people: list[dict[str, Any]] = []
+    by_identity: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        person_id = str(row.get("person_id") or "").strip()
+        # A missing Person relationship must not merge unrelated unlinked
+        # PlanPerson rows merely because their display names happen to match.
+        identity = f"person:{person_id}" if person_id else f"plan-person:{row.get('id')}"
+        position = {
+            "name": str(row.get("position") or ""),
+            "key": str(row.get("position_key") or ""),
+            "team_id": str(row.get("team_id") or ""),
+            "team_name": str(row.get("team_name") or ""),
+        }
+        person = by_identity.get(identity)
+        if person is None:
+            person = {**row, "positions": [position], "position_keys": [position["key"]] if position["key"] else []}
+            by_identity[identity] = person
+            people.append(person)
+            continue
+        if position["key"] and position["key"] not in person["position_keys"]:
+            person["positions"].append(position)
+            person["position_keys"].append(position["key"])
+        for field in ("name", "photo", "status"):
+            if not person.get(field) and row.get(field):
+                person[field] = row[field]
+    return people
+
+
 class PlanningCenterClient:
     def __init__(self, settings: dict[str, Any]):
         self.settings = settings
@@ -308,6 +343,7 @@ class PlanningCenterClient:
                 "photo": person_attrs.get("photo_url") or attrs.get("photo_thumbnail") or person_attrs.get("photo_thumbnail_url") or "",
                 "status": attrs.get("status", ""),
             })
+        people = consolidate_people(people)
         people_by_person_id = {person["person_id"]: person for person in people if person["person_id"]}
         item_payload = await self._get(
             f"{prefix}/items",

--- a/app/services/runtime.py
+++ b/app/services/runtime.py
@@ -716,6 +716,13 @@ class RuntimeService:
                 people[position] = person
             if position_key:
                 people[position_key] = person
+            for scheduled_position in person.get("positions") or []:
+                scheduled_key = str(scheduled_position.get("key") or "").strip()
+                scheduled_name = str(scheduled_position.get("name") or "").strip().casefold()
+                if scheduled_key:
+                    people[scheduled_key] = person
+                if scheduled_name:
+                    people[scheduled_name] = person
         mic_by_id = {mic.get("id"): mic for mic in state.get("mics", [])}
         for position, mic_id in mapping.items():
             if mic_id in mic_by_id:

--- a/app/static/common.js
+++ b/app/static/common.js
@@ -44,16 +44,27 @@ const micMeters = mic => `<div class="meters">${[["BAT",mic.battery_percent],["R
 const positionNameFromKey = key => String(key||"").split("::").at(-1).replace(/\b\w/g,letter=>letter.toUpperCase())||"Position";
 const assignmentEntries = (settings,state) => {
   const selectedKeys=[...new Set(settings.position_keys||[])],labels=settings.position_labels||{},teamIds=new Set((settings.team_ids||[]).map(String)),people=state.people||[],mics=state.mics||[];
-  const peopleByKey=new Map(people.filter(person=>person.position_key).map(person=>[person.position_key,person]));
-  const micByKey=new Map(mics.filter(mic=>mic.assignment?.position_key).map(mic=>[mic.assignment.position_key,mic]));
+  const peopleByKey=new Map();people.forEach(person=>{const keys=person.position_keys?.length?person.position_keys:[person.position_key];keys.filter(Boolean).forEach(key=>peopleByKey.set(key,person))});
+  const micsByKey=new Map();mics.filter(mic=>mic.assignment?.position_key).forEach(mic=>{const key=mic.assignment.position_key,existing=micsByKey.get(key)||[];existing.push(mic);micsByKey.set(key,existing)});
   let keys=selectedKeys;
-  if(!keys.length)keys=[...new Set([...people.map(person=>person.position_key),...mics.map(mic=>mic.assignment?.position_key)].filter(Boolean).filter(key=>!teamIds.size||teamIds.has(String(key).split("::")[0])))];
+  if(!keys.length)keys=[...new Set([...people.flatMap(person=>person.position_keys?.length?person.position_keys:[person.position_key]),...mics.map(mic=>mic.assignment?.position_key)].filter(Boolean).filter(key=>!teamIds.size||teamIds.has(String(key).split("::")[0])))];
   if(!keys.length)return mics.filter(mic=>!teamIds.size||teamIds.has(String(mic.assignment?.team_id||"")));
-  return keys.map(key=>{
-    const meta=labels[key]||{},person=peopleByKey.get(key),positionName=meta.name||person?.position||positionNameFromKey(key),teamId=meta.team_id||person?.team_id||String(key).split("::")[0],teamName=meta.team_name||person?.team_name||"",matchingMic=micByKey.get(key)||mics.find(mic=>String(mic.assignment?.position||"").trim().toLocaleLowerCase()===String(positionName).trim().toLocaleLowerCase());
-    const existing=matchingMic?.assignment||{},assignment={...meta,...existing,...person,position:positionName,position_key:key,team_id:teamId,team_name:teamName,name:person?.name||"Unassigned",photo:person?.photo||""};
-    return matchingMic?{...matchingMic,assignment}:{id:`position-${key}`,name:"No mic",receiver:"No mic assigned",channel:"—",battery_percent:0,rf:0,audio:0,online:false,errors:["No microphone assigned"],placeholder:true,assignment};
-  });
+  const entries=[],seenPeople=new Set();
+  for(const key of keys){
+    const meta=labels[key]||{},person=peopleByKey.get(key),positionName=meta.name||person?.position||positionNameFromKey(key),teamId=meta.team_id||person?.team_id||String(key).split("::")[0],teamName=meta.team_name||person?.team_name||"";
+    if(person){
+      const identity=String(person.person_id||person.id||key);if(seenPeople.has(identity))continue;seenPeople.add(identity);
+      const personKeys=(person.position_keys?.length?person.position_keys:[person.position_key]).filter(positionKey=>keys.includes(positionKey));
+      const positions=personKeys.map(positionKey=>{const positionMeta=labels[positionKey]||{},scheduled=(person.positions||[]).find(item=>item.key===positionKey)||{};return positionMeta.name||scheduled.name||positionNameFromKey(positionKey)});
+      const equipment=[...new Map(personKeys.flatMap(positionKey=>micsByKey.get(positionKey)||[]).map(mic=>[mic.id,mic])).values()];
+      const primary=equipment[0],assignment={...person,position:positions.join(", "),position_key:key,position_keys:personKeys,team_id:teamId,team_name:teamName,name:person.name||"Unassigned",photo:person.photo||""};
+      entries.push(primary?{...primary,assignment,equipment}:{id:`person-${identity}`,name:"No mic",receiver:"No mic assigned",channel:"—",battery_percent:0,rf:0,audio:0,online:false,errors:["No microphone assigned"],placeholder:true,assignment,equipment:[]});
+      continue;
+    }
+    const matchingMic=(micsByKey.get(key)||[])[0]||mics.find(mic=>String(mic.assignment?.position||"").trim().toLocaleLowerCase()===String(positionName).trim().toLocaleLowerCase()),existing=matchingMic?.assignment||{},assignment={...meta,...existing,position:positionName,position_key:key,team_id:teamId,team_name:teamName,name:"Unassigned",photo:""};
+    entries.push(matchingMic?{...matchingMic,assignment,equipment:[matchingMic]}:{id:`position-${key}`,name:"No mic",receiver:"No mic assigned",channel:"—",battery_percent:0,rf:0,audio:0,online:false,errors:["No microphone assigned"],placeholder:true,assignment,equipment:[]});
+  }
+  return entries;
 };
 const filteredPeople = (settings,state) => {
   const people=state.people||[],selectedKeys=[...new Set(settings.position_keys||[])],teamIds=new Set((settings.team_ids||[]).map(String));
@@ -94,7 +105,7 @@ const formatClockTime = (value,timeZone) => {if(!value)return"—";try{return ne
 const formatItemLength = seconds => {const value=Math.max(0,Math.round(Number(seconds)||0));return`${Math.floor(value/60)}:${String(value%60).padStart(2,"0")}`};
 const estimatedItemTime = (item,timing,state) => {const start=Date.parse(timing.service_start_at||"");if(!Number.isFinite(start))return"—";const adjusting=["running","live","controlled"].includes(timing.state),drift=adjusting?Number(timing.overall_delta||0):0;return formatClockTime(new Date(start+(Number(item.starts_after)||0)*1000+drift*1000),state.timezone)};
 const micCardMarkup = (mic,mode="photos",options={}) => {
-  const person=mic.assignment||{},health=micHealth(mic),active=micIsActive(mic),displayName=person.name&&person.name!=="Position unfilled"?person.name:"Unassigned",position=[person.team_name,person.position].filter(Boolean).join(" · ")||"Unmapped position",numericChannel=Number(mic.channel),channel=Number.isFinite(numericChannel)?String(numericChannel).padStart(2,"0"):"—",status=mic.placeholder?"NO MIC":active?`${mic.battery_percent||0}% BAT`:"OFFLINE",hardware=mic.placeholder?"No microphone assigned":[mic.receiver,`Ch ${mic.channel}`].filter(Boolean).join(" · ");
+  const person=mic.assignment||{},health=micHealth(mic),active=micIsActive(mic),displayName=person.name&&person.name!=="Position unfilled"?person.name:"Unassigned",position=[person.team_name,person.position].filter(Boolean).join(" · ")||"Unmapped position",numericChannel=Number(mic.channel),channel=Number.isFinite(numericChannel)?String(numericChannel).padStart(2,"0"):"—",status=mic.placeholder?"NO MIC":active?`${mic.battery_percent||0}% BAT`:"OFFLINE",equipment=mic.equipment||[mic],hardware=mic.placeholder?"No microphone assigned":equipment.map(item=>[item.name||item.receiver,`Ch ${item.channel}`].filter(Boolean).join(" · ")).join(" + ");
   if(mode==="technical")return `<article class="mic-card technical-tile ${health} ${mic.placeholder?"no-mic":""}"><div class="technical-header"><div><strong>${escapeHtml(mic.name||"Mic")}</strong><span>${escapeHtml(position)}</span></div><b>${status}</b></div><div class="technical-person">${escapeHtml(displayName)}</div><div class="technical-stats">${[["Battery",mic.battery_percent],["RF",mic.rf],["Audio",mic.audio]].map(([label,value])=>`<div><span>${label}</span><strong>${value||0}%</strong></div>`).join("")}</div><div class="technical-meta">${escapeHtml(hardware)}${mic.frequency?` · ${escapeHtml(mic.frequency)}`:""}${mic.tx_type?` · ${escapeHtml(mic.tx_type)}`:""}</div>${mic.errors?.length?`<div class="technical-error">${escapeHtml(mic.errors[0])}</div>`:""}</article>`;
   const customIcon=displayName==="Unassigned"?String(options.unassignedIcon||""):"",portrait=person.photo?`<img src="${escapeHtml(person.photo)}" alt="${escapeHtml(displayName)}">`:customIcon?`<img class="unassigned-custom-icon" src="${escapeHtml(customIcon)}" alt="Unassigned">`:displayName==="Unassigned"?`<div class="talent-photo-placeholder"><span class="unassigned-board-icon" role="img" aria-label="Unassigned"></span></div>`:`<div class="talent-photo-placeholder"><span>${initials(displayName)}</span></div>`;
   return `<article class="mic-card talent-tile ${health} ${person.photo?"has-photo":""} ${mic.placeholder?"no-mic":""}"><div class="talent-media">${portrait}</div><div class="talent-gradient"></div><div class="talent-channel"><strong>${channel}</strong><em>${escapeHtml(mic.name||"Mic")}</em><span>${status}</span></div><div class="talent-identity"><div class="mic-person">${escapeHtml(displayName)}</div><div class="mic-position">${escapeHtml(position)}</div><div class="mic-hardware">${escapeHtml(hardware)}</div></div>${micMeters(mic)}</article>`;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -35,7 +35,7 @@ The service-type name and ID are saved together. If Planning Center temporarily 
 5. Drag positions into the desired display order.
 6. Save the dashboard.
 
-Every selected position appears even when no person or microphone is assigned. An open Planning Center position displays **Unassigned**.
+Every selected position appears even when no person or microphone is assigned. When one person holds multiple selected positions, ChurchBoard shows one entry with those positions together and lists every mapped microphone/equipment channel under that person. An open Planning Center position displays **Unassigned**.
 
 ## 3. Add Shure microphones
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from app.models import Dashboard
-from app.services.planning_center import PlanningCenterClient, calculate_timing, item_leader, position_key, selected_service_time, service_items
+from app.services.planning_center import PlanningCenterClient, calculate_timing, consolidate_people, item_leader, position_key, selected_service_time, service_items
 from app.services.shure import ShureClient, battery_percent, percent, transmitter_active
 from app.services.propresenter import ProPresenterClient
 from app.services.runtime import RuntimeService
@@ -76,6 +76,15 @@ class DashboardTests(unittest.TestCase):
 
 
 class PlanningCenterTests(unittest.TestCase):
+    def test_consolidate_people_keeps_one_person_and_all_positions_in_plan_order(self):
+        people = consolidate_people([
+            {"id": "plan-1", "person_id": "caleb", "name": "Caleb Hines", "position": "Acoustic Guitar", "position_key": "band::acoustic guitar", "team_id": "band", "team_name": "Band", "photo": "", "status": "C"},
+            {"id": "plan-2", "person_id": "caleb", "name": "Caleb Hines", "position": "Vocals", "position_key": "band::vocals", "team_id": "band", "team_name": "Band", "photo": "", "status": "C"},
+        ])
+        self.assertEqual(len(people), 1)
+        self.assertEqual([position["name"] for position in people[0]["positions"]], ["Acoustic Guitar", "Vocals"])
+        self.assertEqual(people[0]["position_keys"], ["band::acoustic guitar", "band::vocals"])
+
     def test_manual_plan_wins(self):
         client = PlanningCenterClient({"open_days_before": 0, "open_hours_before": 0, "close_hours_after": 0})
         plans = [{"id": "1", "service_type_id": "a", "starts_at": "2030-01-01T00:00:00+00:00"}, {"id": "2", "service_type_id": "b", "starts_at": "2030-01-02T00:00:00+00:00"}]
@@ -380,6 +389,13 @@ class RuntimeAssignmentTests(unittest.TestCase):
         }
         RuntimeService._apply_assignments(state, {"band::vox 1": "blue"})
         self.assertEqual(state["mics"][0]["assignment"]["name"], "Jordan Lee")
+
+    def test_each_position_mic_maps_to_the_same_consolidated_person(self):
+        person = {"person_id": "caleb", "name": "Caleb Hines", "position": "Acoustic Guitar", "position_key": "band::acoustic guitar", "position_keys": ["band::acoustic guitar", "band::vocals"], "positions": [{"name": "Acoustic Guitar", "key": "band::acoustic guitar"}, {"name": "Vocals", "key": "band::vocals"}]}
+        state = {"people": [person], "mics": [{"id": "instrument", "name": "Instrument"}, {"id": "vocal", "name": "Vocal"}]}
+        RuntimeService._apply_assignments(state, {"band::acoustic guitar": "instrument", "band::vocals": "vocal"})
+        self.assertEqual(state["mics"][0]["assignment"]["person_id"], "caleb")
+        self.assertEqual(state["mics"][1]["assignment"]["person_id"], "caleb")
 
     def test_unfilled_mapped_position_keeps_its_filter_key(self):
         state = {"people": [], "mics": [{"id": "blue", "name": "Blue"}]}


### PR DESCRIPTION
## Summary
- consolidate Planning Center schedule records by person while retaining their assigned-position order
- display one Scheduled Positions & Mics card per person with all assigned roles
- preserve mapped mic assignment and show multiple mapped microphones under the same person

## Why
Planning Center returns one scheduled record per position, which previously produced duplicate person cards and unclear mic assignments.

## Validation
- `python3 -m unittest discover -s tests` (85 passed)
- `node --check app/static/common.js`
- macOS arm64 DMG build completed

Closes #9
Closes #11