### PR TITLE
Update ChurchBoard download links for v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ Choose your computer and click its download link:
 
 | Your computer | Download |
 | --- | --- |
-| **Windows 10 or 11** | **[Download the Windows installer (.exe)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-Windows-x64-Setup.exe)** |
-| **Mac with Apple silicon** — M1, M2, M3, M4, or newer | **[Download the Apple silicon Mac disk image (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-macOS-arm64.dmg)** |
-| **Mac with an Intel processor** | **[Download the Intel Mac disk image (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-macOS-x86_64.dmg)** |
-| **Ubuntu or Debian Linux** | **[Download the Linux installer (.deb)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-Linux-amd64.deb)** |
-| **Other 64-bit desktop Linux** | **[Download the portable Linux package (.tar.gz)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-Linux-x86_64.tar.gz)** |
+| **Windows 10 or 11** | **[Download the Windows installer (.exe)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-Windows-x64-Setup.exe)** |
+| **Mac with Apple silicon** — M1 or newer | **[Download the Apple silicon Mac disk image (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-macOS-arm64.dmg)** |
+| **Mac with an Intel processor** | **[Download the Intel Mac disk image (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-macOS-x86_64.dmg)** |
+| **Ubuntu or Debian Linux** | **[Download the Linux installer (.deb)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-Linux-amd64.deb)** |
+| **Other 64-bit desktop Linux** | **[Download the portable Linux package (.tar.gz)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-Linux-x86_64.tar.gz)** |
 
 Not sure which Mac you have? Choose **Apple menu → About This Mac**. If it says **Chip**, use Apple silicon. If it says **Processor**, use Intel.
 
 **Raspberry Pi:** jump to the [one-command Raspberry Pi installer](#raspberry-pi).
 
-[View all v0.1.25 downloads and release notes](https://github.com/wtapper89/ChurchBoard/releases/tag/v0.1.25)
+[View all v1.3.0 downloads and release notes](https://github.com/wtapper89/ChurchBoard/releases/tag/v1.3.0)
 
 ## Install
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,7 +64,7 @@ This produces a portable `.tar.gz` and a `.deb` for the current architecture.
 
 ## Automated releases
 
-GitHub Actions runs tests on pushes and pull requests. The release workflow can be started manually for test artifacts. Pushing a tag such as `v0.1.25` builds macOS Intel, macOS Apple-silicon, Windows x64, and Linux packages and attaches them to a GitHub Release.
+GitHub Actions runs tests on pushes and pull requests. The release workflow can be started manually for test artifacts. Pushing a tag such as `v1.3.0` builds macOS Intel, macOS Apple-silicon, Windows x64, and Linux packages and attaches them to a GitHub Release.
 
 Before creating a release:
 
@@ -74,8 +74,8 @@ Before creating a release:
 4. Tag the exact commit:
 
    ```bash
-   git tag v0.1.25
-   git push origin v0.1.25
+   git tag v1.3.0
+   git push origin v1.3.0
    ```
 
 ### macOS signing and notarization

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,13 +6,13 @@ ChurchBoard runs a small local web server and displays its interface in a browse
 
 | Platform | Installer |
 | --- | --- |
-| Windows 10 or 11 | **[Download for Windows (.exe)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-Windows-x64-Setup.exe)** |
-| Apple silicon Mac — M1, M2, M3, M4, or newer | **[Download for Apple silicon Mac (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-macOS-arm64.dmg)** |
-| Intel Mac | **[Download for Intel Mac (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-macOS-x86_64.dmg)** |
-| Ubuntu or Debian Linux | **[Download for Linux (.deb)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-Linux-amd64.deb)** |
-| Other 64-bit Linux | **[Download the portable Linux package (.tar.gz)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-0.1.25-Linux-x86_64.tar.gz)** |
+| Windows 10 or 11 | **[Download for Windows (.exe)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-Windows-x64-Setup.exe)** |
+| Apple silicon Mac — M1 or newer | **[Download for Apple silicon Mac (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-macOS-arm64.dmg)** |
+| Intel Mac | **[Download for Intel Mac (.dmg)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-macOS-x86_64.dmg)** |
+| Ubuntu or Debian Linux | **[Download for Linux (.deb)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-Linux-amd64.deb)** |
+| Other 64-bit Linux | **[Download the portable Linux package (.tar.gz)](https://github.com/wtapper89/ChurchBoard/releases/latest/download/ChurchBoard-1.3.0-Linux-x86_64.tar.gz)** |
 
-[See every v0.1.25 download](https://github.com/wtapper89/ChurchBoard/releases/tag/v0.1.25)
+[See every v1.3.0 download](https://github.com/wtapper89/ChurchBoard/releases/tag/v1.3.0)
 
 When the repository is private, sign in to the GitHub account that has access before downloading. The links work normally without sign-in after the repository is public.
 
@@ -31,7 +31,7 @@ http://CHURCHBOARD-COMPUTER-IP:8040/display/main
 ## Windows 10 and 11
 
 1. Use the **Download for Windows** link above.
-2. Open `ChurchBoard-0.1.25-Windows-x64-Setup.exe`.
+2. Open `ChurchBoard-1.3.0-Windows-x64-Setup.exe`.
 3. Run the installer. Leave **Start ChurchBoard automatically when I sign in** checked.
 4. When Windows Firewall asks, allow ChurchBoard on **Private networks** if displays on other production computers need to connect.
 5. ChurchBoard starts and opens its desktop control page.
@@ -44,7 +44,7 @@ To open it later, choose **ChurchBoard** from the Start menu. To uninstall, use 
 
 Choose the package that matches the Mac:
 
-- `arm64` for Apple silicon (M1, M2, M3, M4, and newer)
+- `arm64` for Apple silicon (M1 or newer)
 - `x86_64` for Intel Macs
 
 1. Use the matching **Download for Mac** link above and open the `.dmg`.


### PR DESCRIPTION
## Summary
- update all direct installer filenames from v0.1.25 to v1.3.0
- update the release-notes links and release workflow examples
- simplify Apple silicon guidance to M1 or newer

## Verification
- `python -m unittest discover -s tests` — 94 tests pass
- confirmed no stale v0.1.25 references remain in README, docs, installers, workflows, or app code

After this merges, the merged commit will be tagged `v1.3.0` to build and publish the matching Windows, macOS, and Linux installers.